### PR TITLE
fix: correct path resolution in lambda integration test updater

### DIFF
--- a/tools/@aws-cdk/lambda-integration-test-updater/lib/index.ts
+++ b/tools/@aws-cdk/lambda-integration-test-updater/lib/index.ts
@@ -1,10 +1,11 @@
+import * as path from 'path';
 import { RuntimeIntegrationTestUpdater } from './runtime-updater';
 
 export async function main() {
   const integTestFiles = {
-    NODEJS: __dirname + '../../../../../packages/@aws-cdk-testing/framework-integ/test/aws-lambda-nodejs/test/integ.nodejs.build.images.ts',
-    PYTHON: __dirname + '../../../../../packages/@aws-cdk/aws-lambda-python-alpha/test/integ.python.build.images.ts',
-    OTHER: __dirname + '../../../../../packages/@aws-cdk/aws-lambda-go-alpha/test/integ.function.provided.runtimes.ts',
+    NODEJS: path.resolve(__dirname, '../../../../../packages/@aws-cdk-testing/framework-integ/test/aws-lambda-nodejs/test/integ.nodejs.build.images.ts'),
+    PYTHON: path.resolve(__dirname, '../../../../../packages/@aws-cdk/aws-lambda-python-alpha/test/integ.python.build.images.ts'),
+    OTHER: path.resolve(__dirname, '../../../../../packages/@aws-cdk/aws-lambda-go-alpha/test/integ.function.provided.runtimes.ts'),
   };
   const updater = new RuntimeIntegrationTestUpdater(integTestFiles);
   await updater.execute();

--- a/tools/@aws-cdk/lambda-integration-test-updater/lib/runtime-updater.ts
+++ b/tools/@aws-cdk/lambda-integration-test-updater/lib/runtime-updater.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {Node, Project, SourceFile, ts} from 'ts-morph';
 import SyntaxKind = ts.SyntaxKind;
 
@@ -20,7 +21,7 @@ export class RuntimeIntegrationTestUpdater {
    * @param integTestFiles - An object mapping runtime families to their integration test file paths
    * @param runtimeSourceFilePath - Path to the Lambda runtime source file (defaults to aws-lambda/lib/runtime.ts)
    */
-  constructor(integTestFiles: {[key:string]: string} , runtimeSourceFilePath = __dirname + '../../../../../packages/aws-cdk-lib/aws-lambda/lib/runtime.ts') {
+  constructor(integTestFiles: {[key:string]: string} , runtimeSourceFilePath = path.resolve(__dirname, '../../../../../packages/aws-cdk-lib/aws-lambda/lib/runtime.ts')) {
     this.integTestConfigs = integTestFiles;
     this.project = new Project();
     const runtimeSourceFile =  this.project.addSourceFileAtPath(runtimeSourceFilePath);


### PR DESCRIPTION
## Problem
The Lambda runtime integration test updater tool has path resolution issues in both `index.ts` and `runtime-updater.ts` files. The code uses string concatenation (`__dirname + '...'`) for path resolution which doesn't properly handle directory separators across different operating systems.

## Fix
This PR replaces string concatenation with proper `path.resolve()` calls which:
1. Correctly handles path separators across operating systems
2. Properly resolves relative paths (with `../` segments)
3. Creates absolute paths that work reliably in any execution environment

### Changes
- Added import for Node.js path module: `import * as path from 'path';`
- Replaced string concatenation with `path.resolve()` for all file paths
- Applied consistent path resolution approach throughout the codebase

This fix ensures the Lambda runtime integration test updater tool works correctly across all environments, including CI/CD workflows.