### PR TITLE
fix: add step to fix script permissions in codecov-collect workflow

### DIFF
--- a/.github/workflows/codecov-collect.yml
+++ b/.github/workflows/codecov-collect.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Fix script permissions
+        run: find "$(pwd)" -name "airlift-custom-resource-handlers.sh" -type f -exec chmod +x {} \;
+
       - name: Build Library
         run: npx lerna run build --scope=aws-cdk-lib
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the build fails due to permission errors with `airlift-custom-resource-handlers.sh` scripts. The error was:
```
/bin/sh: line 1: ./scripts/airlift-custom-resource-handlers.sh: Permission denied
```

## Solution

Added a step in the GitHub Actions workflow to explicitly set executable permissions for all `airlift-custom-resource-handlers.sh` files before the build step runs. This ensures that the scripts have the proper execute permissions regardless of how the repository was cloned or checked out.

This is a more robust solution than simply setting the permissions in the repository, as it handles any case where the execute bit might be lost during the repository checkout.