### PR TITLE
fix: add workflow validation tools and script permissions fix

### DIFF
--- a/.github/WORKFLOW_VALIDATION.md
+++ b/.github/WORKFLOW_VALIDATION.md
@@ -1,0 +1,65 @@
+# Validating GitHub Workflows Locally
+
+This project uses GitHub Actions workflows for continuous integration. To validate these workflows locally before pushing changes, you can use the [act](https://github.com/nektos/act) tool.
+
+## Installing Act
+
+### macOS
+```bash
+brew install act
+```
+
+### Linux
+```bash
+curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+```
+
+### Windows
+```bash
+choco install act-cli
+```
+Or with scoop:
+```bash
+scoop install act
+```
+
+## Validating Workflows
+
+After installing `act`, you can validate a workflow by running:
+
+```bash
+# Run a specific workflow
+act -w .github/workflows/codecov-collect.yml
+
+# Run a specific job
+act -j collect -w .github/workflows/codecov-collect.yml
+
+# Run with specific event
+act push -w .github/workflows/codecov-collect.yml
+```
+
+## Troubleshooting
+
+### Docker Requirements
+`act` requires Docker to be installed and running. Make sure Docker is available on your system.
+
+### Secrets and Environments
+For workflows that require secrets or specific environment variables, create a `.secrets` file:
+
+```
+GITHUB_TOKEN=your_personal_access_token
+```
+
+Then run act with the secrets file:
+
+```bash
+act -s GITHUB_TOKEN=your_personal_access_token
+```
+
+### Memory Issues
+If Docker runs out of memory, increase the memory allocation in Docker settings.
+
+## Additional Resources
+
+- [Act GitHub repository](https://github.com/nektos/act)
+- [Act documentation](https://github.com/nektos/act#readme)

--- a/.github/workflows/codecov-collect.yml
+++ b/.github/workflows/codecov-collect.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Fix script permissions
+        run: find "$(pwd)" -name "airlift-custom-resource-handlers.sh" -type f -exec chmod +x {} \;
+
       - name: Build Library
         run: npx lerna run build --scope=aws-cdk-lib
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ You may also find help on these community resources:
 * Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/aws-cdk)
   and tag it with `aws-cdk`
 
+## Workflow Validation
+
+Before submitting changes to GitHub workflows, it's recommended to validate them locally using the [act](https://github.com/nektos/act) tool.
+
+See [.github/WORKFLOW_VALIDATION.md](./.github/WORKFLOW_VALIDATION.md) for instructions on installing and using `act` to validate workflows.
+
+You can also use our validation script:
+```
+./scripts/validate-workflows.sh
+```
+
 ## Roadmap
 
 The AWS CDK Roadmap lets developers know about our upcoming features and priorities to help them plan how to best leverage the CDK and identify opportunities to contribute to the project. See [ROADMAP.md](https://github.com/aws/aws-cdk/blob/main/ROADMAP.md) for more information and FAQs.

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Check if act is installed
+if ! command -v act &> /dev/null; then
+    echo "Error: 'act' is not installed or not in PATH."
+    echo "Please install it:"
+    echo "  macOS: brew install act"
+    echo "  Linux: curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash"
+    echo "  Windows: choco install act-cli or scoop install act"
+    echo "More information: https://github.com/nektos/act"
+    exit 1
+fi
+
+# Validate the codecov-collect.yml workflow
+echo "Validating codecov-collect.yml workflow..."
+cd "$(git rev-parse --show-toplevel)"
+act -n -w .github/workflows/codecov-collect.yml
+
+echo ""
+echo "To run the workflow locally:"
+echo "  act -w .github/workflows/codecov-collect.yml"


### PR DESCRIPTION
## Description

This PR addresses two issues:

1. Fixes the permission error with `airlift-custom-resource-handlers.sh` scripts by adding an explicit step in the GitHub Actions workflow to set executable permissions.
2. Adds tools and documentation for validating GitHub workflows locally using the `act` tool.

### Permission Fix

The build was failing with the error:
```
/bin/sh: line 1: ./scripts/airlift-custom-resource-handlers.sh: Permission denied
```

Added a step in the GitHub Actions workflow to explicitly set executable permissions for all `airlift-custom-resource-handlers.sh` files before the build step runs. This ensures that the scripts have the proper execute permissions regardless of how the repository was cloned or checked out.

### Workflow Validation

Added new tools and documentation to help developers validate GitHub workflows locally before pushing changes:

1. A new script `scripts/validate-workflows.sh` that checks for the presence of `act` and runs workflow validation
2. Documentation in `.github/WORKFLOW_VALIDATION.md` with instructions for installing and using `act`
3. Updated README.md with information about the workflow validation capabilities
  
This makes it easier for contributors to test their workflow changes locally before submitting PRs, which should reduce CI failures.