### PR TITLE
Fix: Use yarn lerna instead of npx lerna to resolve module resolution errors

### DIFF
--- a/.github/workflows/codecov-collect.yml
+++ b/.github/workflows/codecov-collect.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn install
 
       - name: Build Library
-        run: npx lerna run build --scope=aws-cdk-lib
+        run: yarn lerna run build --scope=aws-cdk-lib
 
       - name: Run Core tests
         run: cd packages/aws-cdk-lib && yarn test core


### PR DESCRIPTION
## Fix for module resolution error in CI workflow

### Problem
The current build workflow fails with the error `Cannot find module '@nx/workspace/presets/npm.json'` when running `npx lerna run build`. This occurs because when using `npx`, it loads a cached version of lerna rather than the workspace-installed version. The cached version of Nx is looking for preset files in its own directory structure, not in the local `node_modules` where they actually exist.

### Solution
This PR changes the build command from `npx lerna run build` to `yarn lerna run build`, which ensures that the locally installed versions of lerna and nx are used. This resolves the module path resolution issues by using the correct dependency versions that were installed by the previous `yarn install` step.

### Testing
This change should fix the failing build in the `Codecov Collect` workflow by properly using workspace-installed dependencies.