### PR TITLE
fix: Synchronize AWS SDK versions across packages

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/integ.eks-service-account-sdk-call.js.snapshot/asset.b89975f7b3f26164c931fa6358f91bc80c51661f8629fd4146cc9056a2412780/package.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/integ.eks-service-account-sdk-call.js.snapshot/asset.b89975f7b3f26164c931fa6358f91bc80c51661f8629fd4146cc9056a2412780/package.json
@@ -2,6 +2,6 @@
   "name": "eks-service-account-sdk-call-integ-test",
   "private": "true",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.621.0"
+    "@aws-sdk/client-s3": "3.632.0"
   }
 }

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/sdk-call-integ-test-docker-app/app/package.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/sdk-call-integ-test-docker-app/app/package.json
@@ -2,6 +2,6 @@
   "name": "eks-service-account-sdk-call-integ-test",
   "private": "true",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.621.0"
+    "@aws-sdk/client-s3": "3.632.0"
   }
 }


### PR DESCRIPTION
This PR resolves the dependency version conflict in AWS SDK packages that was causing the yarn-upgrade workflow to fail.

The issue was due to mismatched AWS SDK versions across packages:
- The main integration test package uses `@aws-sdk/client-s3: 3.632.0`
- But the EKS test app was using `@aws-sdk/client-s3: 3.621.0`

This inconsistency was causing the check-yarn-lock.js script to fail, as it strictly verifies that all dependencies are properly defined in the yarn.lock file.

This PR updates the `@aws-sdk/client-s3` version in the EKS test app and its snapshot to match the version used in the main framework-integ package, ensuring consistency across all AWS SDK dependencies.