### PR TITLE
Fix path construction in Lambda Runtime Tests Updater

### DIFF
--- a/tools/@aws-cdk/lambda-integration-test-updater/lib/index.ts
+++ b/tools/@aws-cdk/lambda-integration-test-updater/lib/index.ts
@@ -1,10 +1,11 @@
 import { RuntimeIntegrationTestUpdater } from './runtime-updater';
+import * as path from 'path';
 
 export async function main() {
   const integTestFiles = {
-    NODEJS: __dirname + '../../../../../packages/@aws-cdk-testing/framework-integ/test/aws-lambda-nodejs/test/integ.nodejs.build.images.ts',
-    PYTHON: __dirname + '../../../../../packages/@aws-cdk/aws-lambda-python-alpha/test/integ.python.build.images.ts',
-    OTHER: __dirname + '../../../../../packages/@aws-cdk/aws-lambda-go-alpha/test/integ.function.provided.runtimes.ts',
+    NODEJS: path.resolve(__dirname, '..', '..', '..', '..', '..', 'packages', '@aws-cdk-testing', 'framework-integ', 'test', 'aws-lambda-nodejs', 'test', 'integ.nodejs.build.images.ts'),
+    PYTHON: path.resolve(__dirname, '..', '..', '..', '..', '..', 'packages', '@aws-cdk', 'aws-lambda-python-alpha', 'test', 'integ.python.build.images.ts'),
+    OTHER: path.resolve(__dirname, '..', '..', '..', '..', '..', 'packages', '@aws-cdk', 'aws-lambda-go-alpha', 'test', 'integ.function.provided.runtimes.ts'),
   };
   const updater = new RuntimeIntegrationTestUpdater(integTestFiles);
   await updater.execute();

--- a/tools/@aws-cdk/lambda-integration-test-updater/lib/runtime-updater.ts
+++ b/tools/@aws-cdk/lambda-integration-test-updater/lib/runtime-updater.ts
@@ -1,5 +1,6 @@
 import {Node, Project, SourceFile, ts} from 'ts-morph';
 import SyntaxKind = ts.SyntaxKind;
+import * as path from 'path';
 
 /**
  * RuntimeIntegrationTestUpdater is responsible for updating Lambda runtime integration tests
@@ -20,7 +21,7 @@ export class RuntimeIntegrationTestUpdater {
    * @param integTestFiles - An object mapping runtime families to their integration test file paths
    * @param runtimeSourceFilePath - Path to the Lambda runtime source file (defaults to aws-lambda/lib/runtime.ts)
    */
-  constructor(integTestFiles: {[key:string]: string} , runtimeSourceFilePath = __dirname + '../../../../../packages/aws-cdk-lib/aws-lambda/lib/runtime.ts') {
+  constructor(integTestFiles: {[key:string]: string} , runtimeSourceFilePath = path.resolve(__dirname, '..', '..', '..', '..', '..', 'packages', 'aws-cdk-lib', 'aws-lambda', 'lib', 'runtime.ts')) {
     this.integTestConfigs = integTestFiles;
     this.project = new Project();
     const runtimeSourceFile =  this.project.addSourceFileAtPath(runtimeSourceFilePath);


### PR DESCRIPTION
## Description

This PR fixes path construction issues in the Lambda Runtime Tests Updater tool. Previously, the tool was using string concatenation to construct file paths, which resulted in incorrect path resolution and workflow failures.

### Issue

Path construction for integration test files was using direct string concatenation instead of proper path joining methods:

```typescript
const integTestFiles = {
  NODEJS: __dirname + '../../../../../packages/@aws-cdk-testing/framework-integ/test/aws-lambda-nodejs/test/integ.nodejs.build.images.ts',
  // ...
};
```

This causes two problems:
1. The `__dirname` path already ends with a directory separator
2. The relative path starts without the proper separator pattern (should be `/../../../../../` instead of `../../../../../`)

### Fix

The solution replaces string concatenation with the Node.js `path.resolve()` function to properly handle path construction across different operating systems:

```typescript
const integTestFiles = {
  NODEJS: path.resolve(__dirname, '..', '..', '..', '..', '..', 'packages', '@aws-cdk-testing', 'framework-integ', 'test', 'aws-lambda-nodejs', 'test', 'integ.nodejs.build.images.ts'),
  // ...
};
```

This ensures correct path resolution regardless of the platform (Windows/Linux/macOS) and prevents failures in the Lambda Runtime Tests workflow.