### PR TITLE
fix: improve error handling in update-metadata-regions workflow

### DIFF
--- a/.github/workflows/update-metadata-regions.yml
+++ b/.github/workflows/update-metadata-regions.yml
@@ -13,9 +13,20 @@ jobs:
         env:
           URL: https://d3mqmgkwnwa8vm.cloudfront.net/regions.json
         id: download
+        # Improved to handle transient network issues and validate JSON
         run: |
-          response=$(curl $URL)
-          echo "REGIONS=${response}" >> "$GITHUB_OUTPUT"
+          # Retry logic for better resilience
+          for i in {1..3}; do
+            response=$(curl -s -f $URL)
+            if [ $? -eq 0 ]; then
+              # Validate JSON before using it
+              echo $response | jq empty
+              if [ $? -eq 0 ]; then
+                echo "REGIONS=${response}" >> "$GITHUB_OUTPUT"
+                break
+              fi
+            fi
+          done
           
           status=$(curl -s -o /dev/null -w "%{http_code}" $URL)
           echo "STATUS=${status}" >> "$GITHUB_OUTPUT"

--- a/scripts/update-metadata-regions.js
+++ b/scripts/update-metadata-regions.js
@@ -1,7 +1,17 @@
 module.exports = () => {
-    const fs= require('fs');
-    const regions = JSON.parse(process.env.REGIONS);
-    const content = generateFileContent(regions);
+    const fs = require('fs');
+    let regions;
+    
+    try {
+        regions = JSON.parse(process.env.REGIONS);
+        // Verify that we have a valid array of region strings
+        if (!Array.isArray(regions) || regions.length === 0) {
+            throw new Error('Invalid regions data: Expected non-empty array');
+        }
+    } catch (error) {
+        console.error('Error parsing regions data:', error);
+        process.exit(1);
+    }
     const path = './packages/aws-cdk-lib/region-info/build-tools/metadata.ts';
     fs.writeFileSync(path, content);
 }


### PR DESCRIPTION
This PR adds improved error handling to the update-metadata-regions workflow.

## Changes

- Added retry logic for downloading regions data from the API
- Added JSON validation in the shell script before using the data
- Added proper error handling in the update-metadata-regions.js script
- Added validation to ensure the regions data is a non-empty array

These changes will help prevent workflow failures due to temporary network issues or malformed API responses.