### PR TITLE
fix: Synchronize AWS SDK versions in EKS test app

### DIFF
--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -44,6 +44,12 @@ jobs:
         # These need to be ignored from the `ncu` runs!
         run: |-
           echo "list=$(lerna ls --all --json 2>/dev/null | jq -r 'map(.name) | join(",")')" >> $GITHUB_OUTPUT
+      
+      - name: Get Framework AWS SDK Version
+        id: aws-sdk-version
+        run: |-
+          AWS_SDK_VERSION=$(grep -o '"@aws-sdk/client-s3": "[^"]*"' packages/@aws-cdk-testing/framework-integ/package.json | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo "version=$AWS_SDK_VERSION" >> $GITHUB_OUTPUT
       - name: Run "ncu -u"
         # Upgrade special cases:
         # - Various `@types/*` packages need to be pinned to specific versions due to breaking changes in minor upgrades https://github.com/DefinitelyTyped/DefinitelyTyped/issues/64266
@@ -64,7 +70,13 @@ jobs:
             (cd $(dirname $pj) && ncu --upgrade --reject='constructs,${{ steps.list-packages.outputs.list }}')
           done
           # Upgrade dependencies at an aws-eks integ test docker image
-          cd packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/sdk-call-integ-test-docker-app/app/ && ncu --upgrade --reject='@aws-sdk/*,${{ steps.list-packages.outputs.list }}'
+          cd packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/sdk-call-integ-test-docker-app/app/
+          
+          # Instead of rejecting all AWS SDK updates, we'll update them to match the framework-integ package
+          if [[ -n "${{ steps.aws-sdk-version.outputs.version }}" ]]; then
+            # Update all @aws-sdk/* dependencies to the same version
+            sed -i -E 's/("@aws-sdk\/[^"]+": ")[0-9]+\.[0-9]+\.[0-9]+(")/'"\1${{ steps.aws-sdk-version.outputs.version }}\2"'/g' package.json
+          fi
 
       # This will ensure the current lockfile is up-to-date with the dependency specifications (necessary for "yarn upgrade" to run)
       - name: Run "yarn install"

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/sdk-call-integ-test-docker-app/app/package.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/sdk-call-integ-test-docker-app/app/package.json
@@ -2,6 +2,6 @@
   "name": "eks-service-account-sdk-call-integ-test",
   "private": "true",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.621.0"
+    "@aws-sdk/client-s3": "3.632.0"
   }
 }


### PR DESCRIPTION
This PR fixes the workflow failure caused by inconsistent AWS SDK versions across packages in the monorepo.

## Issue
The EKS test app was using AWS SDK version 3.621.0 while the main framework-integ package was using 3.632.0. This inconsistency causes the `check-yarn-lock.js` script to fail due to missing references in the yarn.lock file.

## Solution
1. Updated the EKS test app to use the same AWS SDK version (3.632.0) as the main framework-integ package
2. Modified the yarn-upgrade workflow to automatically sync AWS SDK versions across packages, using the framework-integ package as the source of truth

This change will prevent similar issues in the future by ensuring all AWS SDK packages are on the same version throughout the monorepo.