### PR TITLE
fix: Use proper multiline syntax for JSON in update-metadata-regions workflow

### DIFF
--- a/.github/workflows/update-metadata-regions.yml
+++ b/.github/workflows/update-metadata-regions.yml
@@ -15,7 +15,9 @@ jobs:
         id: download
         run: |
           response=$(curl $URL)
-          echo "REGIONS=${response}" >> "$GITHUB_OUTPUT"
+          echo "REGIONS<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$response" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
           
           status=$(curl -s -o /dev/null -w "%{http_code}" $URL)
           echo "STATUS=${status}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

This PR fixes the update-metadata-regions.yml workflow that was failing due to improper handling of JSON data in GitHub Actions outputs.

### Problem
When the curl command downloads JSON data and tries to set it directly to GITHUB_OUTPUT, special characters in the JSON can cause the workflow to fail. GitHub Actions requires special formatting for multiline output variables.

### Solution
Updated the workflow to use the multiline output syntax with delimiters (<<EOF and EOF) as per GitHub Actions documentation. This ensures the JSON content is properly set as an output variable regardless of what special characters it might contain.

### References
- GitHub Actions documentation on multiline outputs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings