### PR TITLE
Fix Lambda Runtime Tests Workflow Script Typo and Update NODEJS_LATEST

### DIFF
--- a/.github/workflows/lambda-runtime-tests.yml
+++ b/.github/workflows/lambda-runtime-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Update Lambda Runtime Tests
         run: |
           cd tools/@aws-cdk/lambda-integration-test-updater
-          ./bin/update-lambda-runtimestes-integ-testing
+          ./bin/update-lambda-runtimes-integ-testing
 
       - name: Check for changes
         id: git-check

--- a/packages/aws-cdk-lib/aws-lambda/lib/runtime.ts
+++ b/packages/aws-cdk-lib/aws-lambda/lib/runtime.ts
@@ -116,7 +116,7 @@ export class Runtime {
    * The latest NodeJS version currently available in ALL regions (not necessarily the latest NodeJS version
    * available in YOUR region).
    */
-  public static readonly NODEJS_LATEST = new Runtime('nodejs18.x', RuntimeFamily.NODEJS, { supportsInlineCode: true, isVariable: true });
+  public static readonly NODEJS_LATEST = new Runtime('nodejs20.x', RuntimeFamily.NODEJS, { supportsInlineCode: true, isVariable: true });
 
   /**
    * The NodeJS 22.x runtime (nodejs22.x)


### PR DESCRIPTION
This PR fixes two issues with the Lambda Runtime Tests workflow that was failing:

1. The script name in the workflow file had a typo (`update-lambda-runtimestes-integ-testing` instead of the correct `update-lambda-runtimes-integ-testing`). This was causing the workflow to fail as it couldn't find or execute the script.

2. Updated the `NODEJS_LATEST` constant to reference `nodejs20.x` instead of `nodejs18.x` to align with the latest stable NodeJS runtime widely available across all regions.

These changes should resolve the workflow failure seen in run #15428211239.