### PR TITLE
fix: Synchronize AWS SDK versions in EKS test apps

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/integ.eks-service-account-sdk-call.js.snapshot/asset.b89975f7b3f26164c931fa6358f91bc80c51661f8629fd4146cc9056a2412780/package.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-eks/test/integ.eks-service-account-sdk-call.js.snapshot/asset.b89975f7b3f26164c931fa6358f91bc80c51661f8629fd4146cc9056a2412780/package.json
@@ -2,6 +2,6 @@
   "name": "eks-service-account-sdk-call-integ-test",
   "private": "true",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.621.0"
+    "@aws-sdk/client-s3": "3.632.0"
   }
 }


### PR DESCRIPTION
This PR fixes the AWS SDK version mismatch across different package.json files in the EKS test apps.

The main issue was that the `@aws-cdk-testing/framework-integ` package.json uses version 3.632.0 for `@aws-sdk/client-s3`, but the `integ.eks-service-account-sdk-call.js.snapshot` asset uses version 3.621.0. This inconsistency causes build failures during dependency resolution, especially in workflows like github-merit-badger.

This PR updates the AWS SDK version in the snapshot asset package.json to 3.632.0 to ensure consistent SDK versions across the codebase, which will resolve build failures caused by version conflicts.

Note: As a follow-up improvement, we should also enhance the yarn-upgrade.yml workflow to update all AWS SDK versions in snapshot assets as well, by adding the following code:

```yaml
# Also update all snapshot asset package.json files in the EKS tests
cd ../../../..
find . -path "*/integ.eks*.snapshot/asset.*" -name "package.json" | while read -r file; do
  if grep -q "@aws-sdk/" "$file"; then
    echo "Updating AWS SDK version in $file"
    sed -i -E 's/("@aws-sdk\/[^"]+": ")[0-9]+\.[0-9]+\.[0-9]+(")/'"\1${{ steps.aws-sdk-version.outputs.version }}\2"'/g' "$file"
  fi
done
```