### PR TITLE
Fix PR Labeler Workflow Permissions

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -23,8 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
+      contents: read
+      repository-projects: read
     steps:
-      - uses: cdklabs/pr-triage-manager@main
+      - uses: cdklabs/pr-triage-manager@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This PR fixes the failing PR Labeler workflow by:

1. Adding required permissions to the `copy-labels` job:
   - `issues: write` - Needed for label management across issues
   - `contents: read` - Required to read repository content
   - `repository-projects: read` - For project board integrations

2. Pinning the action to a specific version (`v1.1.0`) instead of using the volatile `@main` reference.

## Root Cause

The PR Labeler workflow was failing because the GitHub token used by the workflow had insufficient permissions to perform the actions required by the `cdklabs/pr-triage-manager` action. Additionally, using the `@main` tag was pulling in potentially breaking changes without warning.

## Testing

This change has been tested by verifying that the required permissions match the documented requirements of the action and follows GitHub Actions best practices for permission scoping and action version pinning.