### PR TITLE
fix: use standard GITHUB_TOKEN in PR linter workflow

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Validate
         uses: ./tools/@aws-cdk/prlint
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.download-if-workflow-run.outputs.pr_number }}
           PR_SHA: ${{ needs.download-if-workflow-run.outputs.pr_sha }}
           LINTER_LOGIN: ${{ vars.LINTER_LOGIN }}


### PR DESCRIPTION
## Problem
The PR linter workflow is failing with a 401 Unauthorized error when attempting to create pull request reviews. This happens because the workflow is using `PROJEN_GITHUB_TOKEN` which might not have the correct permissions or is not properly configured in this fork.

## Solution
This PR changes the authentication to use the standard `GITHUB_TOKEN` which is automatically provided by GitHub Actions and has the necessary permissions to interact with the GitHub API for creating PR reviews.

This ensures the PR linter script has the necessary authentication to interact with the GitHub API when creating or updating pull request reviews.