### PR TITLE
Fix interface property initializers in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,110 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
+import { Construct } from 'constructs';
 
-// Error 1: Wrong type assignment for interface property
+/**
+ * Options for S3 logging
+ */
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  /**
+   * The S3 Bucket for logs
+   */
+  readonly bucket: s3.IBucket;
+
+  /**
+   * Optional S3 object prefix for logs
+   * 
+   * @default - no prefix
+   */
+  readonly prefix?: string;
+
+  /**
+   * Whether to enable encryption of logs
+   * 
+   * @default - false
+   */
+  readonly encrypted?: boolean;
+
+  /**
+   * Whether logging is enabled
+   * 
+   * @default true
+   */
+  readonly enabled?: boolean;
 }
 
-// Error 2: Invalid type declaration
+/**
+ * Options for CloudWatch logging
+ */
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  /**
+   * The CloudWatch log group
+   */
+  readonly logGroup: logs.ILogGroup;
+
+  /**
+   * Optional prefix for CloudWatch log streams
+   * 
+   * @default - no prefix
+   */
+  readonly prefix?: string;
+
+  /**
+   * Whether logging is enabled
+   * 
+   * @default true
+   */
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+/**
+ * Options for project logging
+ */
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  /**
+   * S3 logging options
+   * 
+   * @default - no S3 logging
+   */
+  readonly s3?: S3LoggingOptions;
+
+  /**
+   * CloudWatch logging options
+   * 
+   * @default - no CloudWatch logging
+   */
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
+/**
+ * Creates a new CloudWatch log group
+ * 
+ * @param scope The construct scope
+ * @param id The construct ID
+ * @returns A new CloudWatch LogGroup
+ */
+export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
+  const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
-  const s3Bucket: s3.IBucket = bucket;
-  return s3Bucket;
+/**
+ * Configure S3 logging
+ * 
+ * @param bucket The S3 bucket to use for logging
+ * @returns The configured bucket
+ */
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
+  return bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+/**
+ * Get a default log group for a project
+ * 
+ * @param scope The construct scope
+ * @param id The construct ID
+ * @returns A new CloudWatch LogGroup with default settings
+ */
+export function getDefaultLogGroup(scope: Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id);
+}


### PR DESCRIPTION
This PR fixes TypeScript errors in the project-logs.ts file by:

1. Removing interface property initializers which are not allowed in TypeScript
2. Correctly typing interface properties to match their usage in project.ts
3. Adding proper constructor parameters to the createLogGroup function
4. Adding proper JSDoc comments to improve code readability

The changes address the following specific errors:
- TS1246: An interface property cannot have an initializer
- TS2554: Expected 2-3 arguments, but got 0
- TS2740: Type mismatches between interfaces and their usage

These changes ensure proper TypeScript type checking and prevent build failures.