### PR TITLE
fix: update PR linter to use github.token and add fallback for LINTER_LOGIN

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Validate
         uses: ./tools/@aws-cdk/prlint
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.download-if-workflow-run.outputs.pr_number }}
           PR_SHA: ${{ needs.download-if-workflow-run.outputs.pr_sha }}
-          LINTER_LOGIN: ${{ vars.LINTER_LOGIN }}
+          LINTER_LOGIN: ${{ vars.LINTER_LOGIN || 'github-actions[bot]' }}
           REPO_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
This PR fixes the PR Linter workflow authentication issue by making two minimal changes:

1. Using the default `github.token` instead of the custom `PROJEN_GITHUB_TOKEN` that was not configured
2. Adding a fallback value for `LINTER_LOGIN` to use `github-actions[bot]` if the variable is not set

The PR Linter was failing with a 401 (Unauthorized) error because the GitHub token specified in the workflow configuration (`PROJEN_GITHUB_TOKEN`) was either not being passed to the workflow execution environment, not set in the repository secrets, or had insufficient permissions to create pull request reviews.

By using the default GitHub token, which already has the necessary permissions as defined in the workflow's `permissions` section, the PR Linter will be able to authenticate properly and create pull request reviews.