### PR TITLE
Fix TypeScript errors in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,39 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
+import { Construct } from 'constructs';
 
-// Error 1: Wrong type assignment for interface property
+// Fixed: Removed initializer and corrected type
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
+// Fixed: Removed initializer and corrected type
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  readonly logGroup?: logs.ILogGroup;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+// Fixed: Corrected interface structure with proper types
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  readonly s3?: S3LoggingOptions;
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
+// Fixed: Added required parameters and corrected return type
+export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
+  const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
+// Fixed: Corrected parameter type
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
   const s3Bucket: s3.IBucket = bucket;
   return s3Bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+// Fixed: Changed to a string constant or created a proper LogGroup
+export const defaultLogGroupName: string = "my-log-group";

--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -2,7 +2,7 @@ import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
 import { Construct } from 'constructs';
 
-// Fixed: Removed initializer and corrected type
+// Fixed interface definition without initializers
 export interface S3LoggingOptions {
   readonly bucket: s3.IBucket;
   readonly prefix?: string;
@@ -10,30 +10,30 @@ export interface S3LoggingOptions {
   readonly encrypted?: boolean;
 }
 
-// Fixed: Removed initializer and corrected type
+// Fixed interface definition without initializers
 export interface CloudWatchLoggingOptions {
-  readonly logGroup?: logs.ILogGroup;
+  readonly logGroup?: logs.LogGroup;
   readonly prefix?: string;
   readonly enabled?: boolean;
 }
 
-// Fixed: Corrected interface structure with proper types
+// Fixed interface definition with proper types
 export interface LoggingOptions {
   readonly s3?: S3LoggingOptions;
   readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Fixed: Added required parameters and corrected return type
+// Fixed function with proper return type and arguments
 export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
   const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Fixed: Corrected parameter type
+// Fixed function with proper parameter type
 export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
   const s3Bucket: s3.IBucket = bucket;
   return s3Bucket;
 }
 
-// Fixed: Changed to a string constant or created a proper LogGroup
+// Fixed constant with proper type
 export const defaultLogGroupName: string = "my-log-group";


### PR DESCRIPTION
This PR fixes TypeScript errors in the `project-logs.ts` file that were causing the build to fail.

## Changes:
1. Removed initializers from interface properties (TypeScript interfaces cannot have initializers)
2. Fixed type mismatches in function parameters and return types
3. Added proper types for interface properties
4. Added missing properties to the LoggingOptions interface

## Root Cause:
The original code was attempting to use interfaces as if they were classes with default values, which is not allowed in TypeScript. Interfaces are purely for type checking at compile time and cannot contain initializers or implementation details.

These changes resolve the TypeScript compilation errors and allow the build to complete successfully.