### PR TITLE
Fix TypeScript interface initializers in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,40 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
+import { Construct } from 'constructs';
 
-// Error 1: Wrong type assignment for interface property
+// Fix 1: Removed initializer and corrected type
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
+// Fix 2: Removed initializer and corrected type
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  readonly logGroup: logs.ILogGroup;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+// Fix 3: Corrected interface property type and removed initializer
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  readonly s3?: S3LoggingOptions;
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
+// Fix 4: Corrected return type and constructor usage
+export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
+  const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
+// Fix 5: Corrected parameter type
+export function configureS3Logging(bucket: s3.IBucket) {
   const s3Bucket: s3.IBucket = bucket;
   return s3Bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+// Fix 6: Removed incorrect constant or replaced with a factory function
+export function getDefaultLogGroup(scope: Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id);
+}

--- a/test-project-logs.ts
+++ b/test-project-logs.ts
@@ -1,36 +1,40 @@
-import * as logs from '../../aws-logs';
-import * as s3 from '../../aws-s3';
+import * as logs from './packages/aws-cdk-lib/aws-logs';
+import * as s3 from './packages/aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
-// Error 1: Fixed type assignment for interface property
+// Test interface definitions
 export interface S3LoggingOptions {
   readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Fixed type declaration
 export interface CloudWatchLoggingOptions {
   readonly logGroup: logs.ILogGroup;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Fixed type mismatch in property
 export interface LoggingOptions {
   readonly s3?: S3LoggingOptions;
   readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Fixed return type
+// Test function with proper constructor usage
 export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
   const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Fixed parameter type
+// Test function with proper parameter type
 export function configureS3Logging(bucket: s3.IBucket) {
   const s3Bucket: s3.IBucket = bucket;
   return s3Bucket;
 }
 
-// Error 6: Fixed incompatible type assignment
+// Test function instead of constant
 export function getDefaultLogGroup(scope: Construct, id: string): logs.LogGroup {
   return new logs.LogGroup(scope, id);
 }
+
+console.log('TypeScript validation passed!');


### PR DESCRIPTION
This PR fixes TypeScript errors in the project-logs.ts file by:

1. Removing initializers from interface properties (not allowed in TypeScript)
2. Correcting types for interface properties to match their usage in project.ts
3. Adding required parameters to the LogGroup constructor
4. Replacing the constant with a factory function for defaultLogGroup
5. Fixing parameter and return types in functions

These changes resolve the TypeScript errors that were preventing the build from completing successfully.