### PR TITLE
Fix TypeScript errors in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,38 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
 
-// Error 1: Wrong type assignment for interface property
+// Fixed: Removed initializer from interface property
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
+// Fixed: Removed initializer from interface property
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  readonly logGroup: logs.LogGroup;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+// Fixed: Corrected interface definition
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  readonly s3?: S3LoggingOptions;
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
+// Fixed: Corrected function to provide required arguments and return correct type
+export function createLogGroup(scope: any, id: string): logs.LogGroup {
+  const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
+// Fixed: Corrected parameter type to match expected interface
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
   const s3Bucket: s3.IBucket = bucket;
   return s3Bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+// Fixed: Changed type to match value or vice versa
+export const defaultLogGroupName: string = "my-log-group";

--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts.bak
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts.bak
@@ -1,0 +1,32 @@
+import * as logs from '../../aws-logs';
+import * as s3 from '../../aws-s3';
+
+// Error 1: Wrong type assignment for interface property
+export interface S3LoggingOptions {
+  readonly bucket: number = s3.Bucket;
+}
+
+// Error 2: Invalid type declaration
+export interface CloudWatchLoggingOptions {
+  readonly logGroup: boolean[] = logs.LogGroup;
+}
+
+// Error 3: Type mismatch in property
+export interface LoggingOptions {
+  readonly s3: string = { bucket: new s3.Bucket() };
+}
+
+// Error 4: Wrong return type
+export function createLogGroup(): number[] {
+  const group: logs.LogGroup = new logs.LogGroup();
+  return group;
+}
+
+// Error 5: Invalid parameter type
+export function configureS3Logging(bucket: boolean) {
+  const s3Bucket: s3.IBucket = bucket;
+  return s3Bucket;
+}
+
+// Error 6: Incompatible type assignment
+export const defaultLogGroup: logs.LogGroup = "my-log-group";


### PR DESCRIPTION
This PR fixes the TypeScript compilation errors in the `project-logs.ts` file that were causing the build to fail.

## Changes Made:

1. Removed initializers from interface properties:
   - `S3LoggingOptions.bucket`
   - `CloudWatchLoggingOptions.logGroup`
   - `LoggingOptions.s3`

2. Corrected interface definitions to match how they are used in `project.ts`:
   - Added proper properties to `S3LoggingOptions` (bucket, prefix, enabled, encrypted)
   - Added proper properties to `CloudWatchLoggingOptions` (logGroup, prefix, enabled)
   - Changed `LoggingOptions` to have optional `s3` and `cloudWatch` properties

3. Fixed the `createLogGroup` function:
   - Added required parameters (scope, id)
   - Corrected return type to `logs.LogGroup`

4. Fixed type mismatches:
   - Changed parameter type in `configureS3Logging` to match expected interface
   - Renamed `defaultLogGroup` to `defaultLogGroupName` and changed its type to string

These changes resolve all the TypeScript compilation errors that were preventing the build from succeeding.