### PR TITLE
Fix code coverage for token.ts, feature-flags.ts, and runtime-info.ts

### DIFF
--- a/packages/aws-cdk-lib/core/test/feature-flags.test.ts
+++ b/packages/aws-cdk-lib/core/test/feature-flags.test.ts
@@ -1,6 +1,19 @@
 import * as cxapi from '../../cx-api';
 import { FeatureFlags, Stack } from '../lib';
 
+// Mock the CURRENT_VERSION_EXPIRED_FLAGS array for testing
+jest.mock('../../cx-api', () => {
+  const originalModule = jest.requireActual('../../cx-api');
+  return {
+    ...originalModule,
+    CURRENT_VERSION_EXPIRED_FLAGS: ['expired-flag'],
+    futureFlagDefault: jest.fn().mockImplementation((flag) => {
+      if (flag === 'test-flag') return true;
+      return false;
+    }),
+  };
+});
+
 describe('feature flags', () => {
   describe('isEnabled', () => {
     test('returns true when the flag is enabled', () => {
@@ -30,6 +43,40 @@ describe('feature flags', () => {
 
       const actual = FeatureFlags.of(stack).isEnabled(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT);
       expect(actual).toEqual(true);
+    });
+    
+    test('returns true for expired flags', () => {
+      const stack = new Stack();
+      
+      // This should return true since it's an expired flag
+      const actual = FeatureFlags.of(stack).isEnabled('expired-flag');
+      expect(actual).toEqual(true);
+    });
+    
+    test('throws error when expired flag is explicitly set', () => {
+      const stack = new Stack();
+      stack.node.setContext('expired-flag', false);
+      
+      // This should throw an error since we're trying to set an expired flag
+      expect(() => {
+        FeatureFlags.of(stack).isEnabled('expired-flag');
+      }).toThrow(/Unsupported feature flag 'expired-flag'/);
+    });
+    
+    test('returns default value for known flag', () => {
+      const stack = new Stack();
+      
+      // This should return the mocked default value (true)
+      const actual = FeatureFlags.of(stack).isEnabled('test-flag');
+      expect(actual).toEqual(true);
+    });
+    
+    test('false is properly evaluated as boolean false', () => {
+      const stack = new Stack();
+      stack.node.setContext('test-flag', false);
+      
+      const actual = FeatureFlags.of(stack).isEnabled('test-flag');
+      expect(actual).toEqual(false);
     });
   });
 });

--- a/packages/aws-cdk-lib/core/test/feature-flags.test.ts.bak
+++ b/packages/aws-cdk-lib/core/test/feature-flags.test.ts.bak
@@ -1,0 +1,35 @@
+import * as cxapi from '../../cx-api';
+import { FeatureFlags, Stack } from '../lib';
+
+describe('feature flags', () => {
+  describe('isEnabled', () => {
+    test('returns true when the flag is enabled', () => {
+      const stack = new Stack();
+      stack.node.setContext(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT, true);
+
+      const actual = FeatureFlags.of(stack).isEnabled(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT);
+      expect(actual).toEqual(true);
+    });
+
+    test('falls back to the default', () => {
+      const stack = new Stack();
+
+      expect(FeatureFlags.of(stack).isEnabled(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT)).toEqual(
+        cxapi.futureFlagDefault(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT));
+    });
+
+    test('invalid flag', () => {
+      const stack = new Stack();
+
+      expect(FeatureFlags.of(stack).isEnabled('non-existent-flag')).toEqual(false);
+    });
+
+    test('strings are evaluated as boolean', () => {
+      const stack = new Stack();
+      stack.node.setContext(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT, 'true');
+
+      const actual = FeatureFlags.of(stack).isEnabled(cxapi.NEW_STYLE_STACK_SYNTHESIS_CONTEXT);
+      expect(actual).toEqual(true);
+    });
+  });
+});

--- a/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts
+++ b/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { App, MetadataEntry, Stack, Stage } from '../../lib';
+import { App, MetadataEntry, NestedStack, Stack, Stage } from '../../lib';
 import { MetadataType } from '../../lib/metadata-resource';
 import {
   constructInfoFromConstruct,
@@ -174,5 +174,121 @@ describe('runtime-info', () => {
       info.fqn === 'policyValidation.test-plugin.rule1' && 
       info.version === '0.0.0'
     )).toBeTruthy();
+  });
+
+  test('jsii agent version sanitizes special characters', () => {
+    // Save original JSII_AGENT
+    const originalJsiiAgent = process.env.JSII_AGENT;
+    
+    try {
+      // Set JSII_AGENT with special characters
+      process.env.JSII_AGENT = 'DotNet/5.0.3/.NETCoreApp,Version=v3.1/1.0.0.0';
+      
+      // Create a stack to trigger getJsiiAgentVersion
+      const app = new App();
+      const stack = new Stack(app, 'TestStack');
+      
+      // Get runtime info
+      const infos = constructInfoFromStack(stack);
+      
+      // Find the jsii runtime entry
+      const jsiiRuntime = infos.find(info => info.fqn === 'jsii-runtime.Runtime');
+      
+      // Verify special characters were sanitized
+      expect(jsiiRuntime).toBeDefined();
+      expect(jsiiRuntime!.version).toBe('DotNet/5.0.3/.NETCoreApp-Version=v3.1/1.0.0.0');
+    } finally {
+      // Restore original JSII_AGENT
+      if (originalJsiiAgent === undefined) {
+        delete process.env.JSII_AGENT;
+      } else {
+        process.env.JSII_AGENT = originalJsiiAgent;
+      }
+    }
+  });
+
+  test('jsii agent version defaults to node.js version when JSII_AGENT is not set', () => {
+    // Save original JSII_AGENT
+    const originalJsiiAgent = process.env.JSII_AGENT;
+    
+    try {
+      // Unset JSII_AGENT
+      delete process.env.JSII_AGENT;
+      
+      // Create a stack to trigger getJsiiAgentVersion
+      const app = new App();
+      const stack = new Stack(app, 'TestStack');
+      
+      // Get runtime info
+      const infos = constructInfoFromStack(stack);
+      
+      // Find the jsii runtime entry
+      const jsiiRuntime = infos.find(info => info.fqn === 'jsii-runtime.Runtime');
+      
+      // Verify it uses node.js version
+      expect(jsiiRuntime).toBeDefined();
+      expect(jsiiRuntime!.version).toContain('node.js/');
+      expect(jsiiRuntime!.version).toContain(process.version);
+    } finally {
+      // Restore original JSII_AGENT
+      if (originalJsiiAgent === undefined) {
+        delete process.env.JSII_AGENT;
+      } else {
+        process.env.JSII_AGENT = originalJsiiAgent;
+      }
+    }
+  });
+
+  test('constructsInStack stops at nested stack boundaries', () => {
+    // GIVEN
+    const app = new App();
+    const parentStack = new Stack(app, 'ParentStack');
+    
+    // Create a nested stack
+    const nestedStack = new NestedStack(parentStack, 'NestedStack');
+    
+    // Add constructs to both stacks
+    new Construct(parentStack, 'ParentConstruct');
+    new Construct(nestedStack, 'NestedConstruct');
+    
+    // WHEN
+    const parentInfos = constructInfoFromStack(parentStack);
+    const nestedInfos = constructInfoFromStack(nestedStack);
+    
+    // THEN
+    // Both should have their own constructs but not the other's
+    expect(parentInfos.length).toBeGreaterThan(0);
+    expect(nestedInfos.length).toBeGreaterThan(0);
+    
+    // The nested stack should be treated as a boundary
+    const parentPaths = parentInfos.map(info => info.fqn);
+    const nestedPaths = nestedInfos.map(info => info.fqn);
+    
+    // Both should have jsii runtime
+    expect(parentPaths).toContain('jsii-runtime.Runtime');
+    expect(nestedPaths).toContain('jsii-runtime.Runtime');
+  });
+
+  test('constructsInStack stops at stage boundaries', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'Stack');
+    
+    // Add constructs
+    new Construct(app, 'AppConstruct');
+    new Construct(stage, 'StageConstruct');
+    new Construct(stack, 'StackConstruct');
+    
+    // WHEN
+    const stackInfos = constructInfoFromStack(stack);
+    
+    // THEN
+    // Should have stack constructs but not app or stage constructs
+    expect(stackInfos.length).toBeGreaterThan(0);
+    
+    // All constructs should be from the stack or below
+    const constructPaths = stackInfos.map(info => info.fqn).filter(fqn => !fqn.startsWith('jsii-runtime'));
+    expect(constructPaths.length).toBeGreaterThan(0);
   });
 });

--- a/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts
+++ b/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts
@@ -1,41 +1,178 @@
-import { MetadataEntry } from 'constructs';
+import { Construct } from 'constructs';
+import { App, MetadataEntry, Stack, Stage } from '../../lib';
 import { MetadataType } from '../../lib/metadata-resource';
 import {
+  constructInfoFromConstruct,
+  constructInfoFromStack,
   filterMetadataType,
 } from '../../lib/private/runtime-info';
+import { IPolicyValidationPluginBeta1 } from '../../lib/validation';
 
-test('test filterMetadataType correct filter', () => {
-  const metadata: MetadataEntry[] = [
-    { type: MetadataType.CONSTRUCT, data: { hello: 'world' } },
-    {
-      type: MetadataType.METHOD,
-      data: {
+describe('runtime-info', () => {
+  test('test filterMetadataType correct filter', () => {
+    const metadata: MetadataEntry[] = [
+      { type: MetadataType.CONSTRUCT, data: { hello: 'world' } },
+      {
+        type: MetadataType.METHOD,
+        data: {
+          bool: true,
+          nested: { foo: 'bar' },
+          arr: [1, 2, 3],
+          str: 'foo',
+          arrOfObjects: [{ foo: { hello: 'world' } }],
+        },
+      },
+      {
+        type: 'hello',
+        data: { bool: true, nested: { foo: 'bar' }, arr: [1, 2, 3], str: 'foo' },
+      },
+      {
+        type: MetadataType.FEATURE_FLAG,
+        data: 'foobar',
+      },
+    ];
+
+    expect(filterMetadataType(metadata)).toEqual([
+      { hello: 'world' },
+      {
         bool: true,
         nested: { foo: 'bar' },
         arr: [1, 2, 3],
         str: 'foo',
         arrOfObjects: [{ foo: { hello: 'world' } }],
       },
-    },
-    {
-      type: 'hello',
-      data: { bool: true, nested: { foo: 'bar' }, arr: [1, 2, 3], str: 'foo' },
-    },
-    {
-      type: MetadataType.FEATURE_FLAG,
-      data: 'foobar',
-    },
-  ];
+      'foobar',
+    ]);
+  });
 
-  expect(filterMetadataType(metadata)).toEqual([
-    { hello: 'world' },
-    {
-      bool: true,
-      nested: { foo: 'bar' },
-      arr: [1, 2, 3],
-      str: 'foo',
-      arrOfObjects: [{ foo: { hello: 'world' } }],
-    },
-    'foobar',
-  ]);
+  test('constructInfoFromConstruct returns undefined when no jsii runtime info', () => {
+    // GIVEN
+    class TestConstruct extends Construct {
+      constructor(scope: Construct, id: string) {
+        super(scope, id);
+      }
+    }
+    const construct = new TestConstruct(new Stack(), 'TestConstruct');
+
+    // WHEN
+    const info = constructInfoFromConstruct(construct);
+
+    // THEN
+    expect(info).toBeUndefined();
+  });
+
+  test('constructInfoFromConstruct throws when jsii runtime info is malformed', () => {
+    // GIVEN
+    class TestConstruct extends Construct {
+      constructor(scope: Construct, id: string) {
+        super(scope, id);
+      }
+    }
+    const construct = new TestConstruct(new Stack(), 'TestConstruct');
+    
+    // Add malformed jsii runtime info
+    Object.getPrototypeOf(construct).constructor[Symbol.for('jsii.rtti')] = { 
+      // Missing version field
+      fqn: 'test.TestConstruct'
+    };
+
+    // THEN
+    expect(() => constructInfoFromConstruct(construct)).toThrow(/malformed jsii runtime info/);
+  });
+
+  test('constructInfoFromStack collects info from all constructs', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    new Construct(stack, 'Child1');
+    new Construct(stack, 'Child2');
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.length).toBeGreaterThan(0);
+    // Should include jsii runtime
+    expect(infos.some(info => info.fqn === 'jsii-runtime.Runtime')).toBeTruthy();
+  });
+
+  test('validation plugin info is added to stack info', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'TestStack');
+    
+    // Create a mock validation plugin
+    const mockPlugin: IPolicyValidationPluginBeta1 = {
+      name: 'test-plugin',
+      version: '1.0.0',
+      validate: jest.fn(),
+      ruleIds: ['rule1', 'rule2'],
+    };
+    
+    // Add the plugin to the stage
+    stage.policyValidationBeta1.push(mockPlugin);
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.some(info => 
+      info.fqn === 'policyValidation.test-plugin.rule1|rule2' && 
+      info.version === '1.0.0'
+    )).toBeTruthy();
+  });
+
+  test('validation plugin without ruleIds is handled correctly', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'TestStack');
+    
+    // Create a mock validation plugin without ruleIds
+    const mockPlugin: IPolicyValidationPluginBeta1 = {
+      name: 'test-plugin',
+      version: '1.0.0',
+      validate: jest.fn(),
+      // No ruleIds
+    };
+    
+    // Add the plugin to the stage
+    stage.policyValidationBeta1.push(mockPlugin);
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.some(info => 
+      info.fqn === 'policyValidation.test-plugin' && 
+      info.version === '1.0.0'
+    )).toBeTruthy();
+  });
+
+  test('validation plugin without version uses default version', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'TestStack');
+    
+    // Create a mock validation plugin without version
+    const mockPlugin: IPolicyValidationPluginBeta1 = {
+      name: 'test-plugin',
+      validate: jest.fn(),
+      ruleIds: ['rule1'],
+    };
+    
+    // Add the plugin to the stage
+    stage.policyValidationBeta1.push(mockPlugin);
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.some(info => 
+      info.fqn === 'policyValidation.test-plugin.rule1' && 
+      info.version === '0.0.0'
+    )).toBeTruthy();
+  });
 });

--- a/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts.bak
+++ b/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts.bak
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { App, MetadataEntry, Stack, Stage } from '../../lib';
+import { App, MetadataEntry, NestedStack, Stack, Stage } from '../../lib';
 import { MetadataType } from '../../lib/metadata-resource';
 import {
   constructInfoFromConstruct,
@@ -8,38 +8,234 @@ import {
 } from '../../lib/private/runtime-info';
 import { IPolicyValidationPluginBeta1 } from '../../lib/validation';
 
-test('test filterMetadataType correct filter', () => {
-  const metadata: MetadataEntry[] = [
-    { type: MetadataType.CONSTRUCT, data: { hello: 'world' } },
-    {
-      type: MetadataType.METHOD,
-      data: {
+describe('runtime-info', () => {
+  test('test filterMetadataType correct filter', () => {
+    const metadata: MetadataEntry[] = [
+      { type: MetadataType.CONSTRUCT, data: { hello: 'world' } },
+      {
+        type: MetadataType.METHOD,
+        data: {
+          bool: true,
+          nested: { foo: 'bar' },
+          arr: [1, 2, 3],
+          str: 'foo',
+          arrOfObjects: [{ foo: { hello: 'world' } }],
+        },
+      },
+      {
+        type: 'hello',
+        data: { bool: true, nested: { foo: 'bar' }, arr: [1, 2, 3], str: 'foo' },
+      },
+      {
+        type: MetadataType.FEATURE_FLAG,
+        data: 'foobar',
+      },
+    ];
+
+    expect(filterMetadataType(metadata)).toEqual([
+      { hello: 'world' },
+      {
         bool: true,
         nested: { foo: 'bar' },
         arr: [1, 2, 3],
         str: 'foo',
         arrOfObjects: [{ foo: { hello: 'world' } }],
       },
-    },
-    {
-      type: 'hello',
-      data: { bool: true, nested: { foo: 'bar' }, arr: [1, 2, 3], str: 'foo' },
-    },
-    {
-      type: MetadataType.FEATURE_FLAG,
-      data: 'foobar',
-    },
-  ];
+      'foobar',
+    ]);
+  });
 
-  expect(filterMetadataType(metadata)).toEqual([
-    { hello: 'world' },
-    {
-      bool: true,
-      nested: { foo: 'bar' },
-      arr: [1, 2, 3],
-      str: 'foo',
-      arrOfObjects: [{ foo: { hello: 'world' } }],
-    },
-    'foobar',
-  ]);
+  test('constructInfoFromConstruct returns undefined when no jsii runtime info', () => {
+    // GIVEN
+    class TestConstruct extends Construct {
+      constructor(scope: Construct, id: string) {
+        super(scope, id);
+      }
+    }
+    const construct = new TestConstruct(new Stack(), 'TestConstruct');
+
+    // WHEN
+    const info = constructInfoFromConstruct(construct);
+
+    // THEN
+    expect(info).toBeUndefined();
+  });
+
+  test('constructInfoFromConstruct throws when jsii runtime info is malformed', () => {
+    // GIVEN
+    class TestConstruct extends Construct {
+      constructor(scope: Construct, id: string) {
+        super(scope, id);
+      }
+    }
+    const construct = new TestConstruct(new Stack(), 'TestConstruct');
+    
+    // Add malformed jsii runtime info
+    Object.getPrototypeOf(construct).constructor[Symbol.for('jsii.rtti')] = { 
+      // Missing version field
+      fqn: 'test.TestConstruct'
+    };
+
+    // THEN
+    expect(() => constructInfoFromConstruct(construct)).toThrow(/malformed jsii runtime info/);
+  });
+
+  test('constructInfoFromStack collects info from all constructs', () => {
+    // GIVEN
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    new Construct(stack, 'Child1');
+    new Construct(stack, 'Child2');
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.length).toBeGreaterThan(0);
+    // Should include jsii runtime
+    expect(infos.some(info => info.fqn === 'jsii-runtime.Runtime')).toBeTruthy();
+  });
+
+  test('validation plugin info is added to stack info', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'TestStack');
+    
+    // Create a mock validation plugin
+    const mockPlugin: IPolicyValidationPluginBeta1 = {
+      name: 'test-plugin',
+      version: '1.0.0',
+      validate: jest.fn(),
+      ruleIds: ['rule1', 'rule2'],
+    };
+    
+    // Add the plugin to the stage
+    stage.policyValidationBeta1.push(mockPlugin);
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.some(info => 
+      info.fqn === 'policyValidation.test-plugin.rule1|rule2' && 
+      info.version === '1.0.0'
+    )).toBeTruthy();
+  });
+
+  test('validation plugin without ruleIds is handled correctly', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'TestStack');
+    
+    // Create a mock validation plugin without ruleIds
+    const mockPlugin: IPolicyValidationPluginBeta1 = {
+      name: 'test-plugin',
+      version: '1.0.0',
+      validate: jest.fn(),
+      // No ruleIds
+    };
+    
+    // Add the plugin to the stage
+    stage.policyValidationBeta1.push(mockPlugin);
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.some(info => 
+      info.fqn === 'policyValidation.test-plugin' && 
+      info.version === '1.0.0'
+    )).toBeTruthy();
+  });
+
+  test('validation plugin without version uses default version', () => {
+    // GIVEN
+    const app = new App();
+    const stage = new Stage(app, 'Stage');
+    const stack = new Stack(stage, 'TestStack');
+    
+    // Create a mock validation plugin without version
+    const mockPlugin: IPolicyValidationPluginBeta1 = {
+      name: 'test-plugin',
+      validate: jest.fn(),
+      ruleIds: ['rule1'],
+    };
+    
+    // Add the plugin to the stage
+    stage.policyValidationBeta1.push(mockPlugin);
+
+    // WHEN
+    const infos = constructInfoFromStack(stack);
+
+    // THEN
+    expect(infos.some(info => 
+      info.fqn === 'policyValidation.test-plugin.rule1' && 
+      info.version === '0.0.0'
+    )).toBeTruthy();
+  });
+
+  test('jsii agent version sanitizes special characters', () => {
+    // Save original JSII_AGENT
+    const originalJsiiAgent = process.env.JSII_AGENT;
+    
+    try {
+      // Set JSII_AGENT with special characters
+      process.env.JSII_AGENT = 'DotNet/5.0.3/.NETCoreApp,Version=v3.1/1.0.0.0';
+      
+      // Create a stack to trigger getJsiiAgentVersion
+      const app = new App();
+      const stack = new Stack(app, 'TestStack');
+      
+      // Get runtime info
+      const infos = constructInfoFromStack(stack);
+      
+      // Find the jsii runtime entry
+      const jsiiRuntime = infos.find(info => info.fqn === 'jsii-runtime.Runtime');
+      
+      // Verify special characters were sanitized
+      expect(jsiiRuntime).toBeDefined();
+      expect(jsiiRuntime!.version).toBe('DotNet/5.0.3/.NETCoreApp-Version=v3.1/1.0.0.0');
+    } finally {
+      // Restore original JSII_AGENT
+      if (originalJsiiAgent === undefined) {
+        delete process.env.JSII_AGENT;
+      } else {
+        process.env.JSII_AGENT = originalJsiiAgent;
+      }
+    }
+  });
+
+  test('jsii agent version defaults to node.js version when JSII_AGENT is not set', () => {
+    // Save original JSII_AGENT
+    const originalJsiiAgent = process.env.JSII_AGENT;
+    
+    try {
+      // Unset JSII_AGENT
+      delete process.env.JSII_AGENT;
+      
+      // Create a stack to trigger getJsiiAgentVersion
+      const app = new App();
+      const stack = new Stack(app, 'TestStack');
+      
+      // Get runtime info
+      const infos = constructInfoFromStack(stack);
+      
+      // Find the jsii runtime entry
+      const jsiiRuntime = infos.find(info => info.fqn === 'jsii-runtime.Runtime');
+      
+      // Verify it uses node.js version
+      expect(jsiiRuntime).toBeDefined();
+      expect(jsiiRuntime!.version).toContain('node.js/');
+      expect(jsiiRuntime!.version).toContain(process.version);
+    } finally {
+      // Restore original JSII_AGENT
+      if (originalJsiiAgent === undefined) {
+        delete process.env.JSII_AGENT;
+      } else {
+        process.env.JSII_AGENT = originalJsiiAgent;
+      }
+    }
+  });
 });

--- a/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts.bak
+++ b/packages/aws-cdk-lib/core/test/private/runtime-info.test.ts.bak
@@ -1,0 +1,45 @@
+import { Construct } from 'constructs';
+import { App, MetadataEntry, Stack, Stage } from '../../lib';
+import { MetadataType } from '../../lib/metadata-resource';
+import {
+  constructInfoFromConstruct,
+  constructInfoFromStack,
+  filterMetadataType,
+} from '../../lib/private/runtime-info';
+import { IPolicyValidationPluginBeta1 } from '../../lib/validation';
+
+test('test filterMetadataType correct filter', () => {
+  const metadata: MetadataEntry[] = [
+    { type: MetadataType.CONSTRUCT, data: { hello: 'world' } },
+    {
+      type: MetadataType.METHOD,
+      data: {
+        bool: true,
+        nested: { foo: 'bar' },
+        arr: [1, 2, 3],
+        str: 'foo',
+        arrOfObjects: [{ foo: { hello: 'world' } }],
+      },
+    },
+    {
+      type: 'hello',
+      data: { bool: true, nested: { foo: 'bar' }, arr: [1, 2, 3], str: 'foo' },
+    },
+    {
+      type: MetadataType.FEATURE_FLAG,
+      data: 'foobar',
+    },
+  ];
+
+  expect(filterMetadataType(metadata)).toEqual([
+    { hello: 'world' },
+    {
+      bool: true,
+      nested: { foo: 'bar' },
+      arr: [1, 2, 3],
+      str: 'foo',
+      arrOfObjects: [{ foo: { hello: 'world' } }],
+    },
+    'foobar',
+  ]);
+});

--- a/packages/aws-cdk-lib/core/test/token.test.ts
+++ b/packages/aws-cdk-lib/core/test/token.test.ts
@@ -109,6 +109,19 @@ describe('Tokenization', () => {
     });
   });
 
+  describe('reverseNumber', () => {
+    test('returns undefined for non-token number', () => {
+      expect(Tokenization.reverseNumber(123)).toBeUndefined();
+    });
+
+    test('returns token for encoded number', () => {
+      const original = Token.asAny(123);
+      const encoded = Token.asNumber(original);
+      const reversed = Tokenization.reverseNumber(encoded);
+      expect(reversed).toBeDefined();
+    });
+  });
+
   describe('reverseCompleteString', () => {
     test('returns token for encoded token string', () => {
       const original = Token.asAny(123);
@@ -122,6 +135,18 @@ describe('Tokenization', () => {
       expect(() => {
         Tokenization.reverseCompleteString(`foo ${token}`);
       }).toThrow(/must not be a concatenation/);
+    });
+  });
+  describe('reverseList', () => {
+    test('returns undefined for non-token list', () => {
+      expect(Tokenization.reverseList(['foo', 'bar'])).toBeUndefined();
+    });
+
+    test('returns token for encoded list', () => {
+      const original = Token.asAny(['foo', 'bar']);
+      const encoded = Token.asList(original);
+      const reversed = Tokenization.reverseList(encoded);
+      expect(reversed).toBeDefined();
     });
   });
 
@@ -147,6 +172,18 @@ describe('Tokenization', () => {
       }).toThrow();
       
       expect(Tokenization.reverse(`foo ${token}`, { failConcat: false })).toBeUndefined();
+    });
+    
+    test('reverses array values', () => {
+      const original = Token.asAny(['foo', 'bar']);
+      const encoded = Token.asList(original);
+      expect(Tokenization.reverse(encoded)).toBeDefined();
+    });
+    
+    test('reverses number values', () => {
+      const original = Token.asAny(123);
+      const encoded = Token.asNumber(original);
+      expect(Tokenization.reverse(encoded)).toBeDefined();
     });
   });
 

--- a/packages/aws-cdk-lib/core/test/token.test.ts
+++ b/packages/aws-cdk-lib/core/test/token.test.ts
@@ -1,0 +1,293 @@
+import { Stack } from '../lib';
+import { JsonNull, Token, TokenComparison, Tokenization, withResolved } from '../lib/token';
+import { IResolvable, IResolveContext } from '../lib/resolvable';
+
+describe('Token', () => {
+  describe('isUnresolved', () => {
+    test('returns true for tokens', () => {
+      expect(Token.isUnresolved(Token.asAny('foo'))).toBe(true);
+    });
+
+    test('returns false for non-tokens', () => {
+      expect(Token.isUnresolved('foo')).toBe(false);
+      expect(Token.isUnresolved(123)).toBe(false);
+      expect(Token.isUnresolved({})).toBe(false);
+      expect(Token.isUnresolved([])).toBe(false);
+    });
+  });
+
+  describe('asString', () => {
+    test('returns string for string value', () => {
+      expect(Token.asString('foo')).toBe('foo');
+    });
+
+    test('returns encoded token for non-string value', () => {
+      const token = Token.asString(123);
+      expect(typeof token).toBe('string');
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+
+    test('handles display hint', () => {
+      const token = Token.asString(123, { displayHint: 'test-hint' });
+      expect(typeof token).toBe('string');
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+  });
+
+  describe('asNumber', () => {
+    test('returns number for number value', () => {
+      expect(Token.asNumber(123)).toBe(123);
+    });
+
+    test('returns encoded token for non-number value', () => {
+      const token = Token.asNumber('foo');
+      expect(typeof token).toBe('number');
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+  });
+
+  describe('asList', () => {
+    test('returns string array for string array value', () => {
+      expect(Token.asList(['foo', 'bar'])).toEqual(['foo', 'bar']);
+    });
+
+    test('returns encoded token for non-string-array value', () => {
+      const token = Token.asList(123);
+      expect(Array.isArray(token)).toBe(true);
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+
+    test('handles display hint', () => {
+      const token = Token.asList(123, { displayHint: 'test-hint' });
+      expect(Array.isArray(token)).toBe(true);
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+  });
+
+  describe('asAny', () => {
+    test('returns IResolvable for any value', () => {
+      const token = Token.asAny('foo');
+      expect(Tokenization.isResolvable(token)).toBe(true);
+    });
+
+    test('returns original IResolvable for IResolvable value', () => {
+      const original: IResolvable = {
+        creationStack: [],
+        resolve: () => 'foo',
+      };
+      const token = Token.asAny(original);
+      expect(token).toBe(original);
+    });
+  });
+
+  describe('compareStrings', () => {
+    test('returns SAME for identical strings', () => {
+      expect(Token.compareStrings('foo', 'foo')).toBe(TokenComparison.SAME);
+    });
+
+    test('returns DIFFERENT for different strings', () => {
+      expect(Token.compareStrings('foo', 'bar')).toBe(TokenComparison.DIFFERENT);
+    });
+
+    test('returns ONE_UNRESOLVED when one string is a token', () => {
+      expect(Token.compareStrings('foo', Token.asString(123))).toBe(TokenComparison.ONE_UNRESOLVED);
+    });
+
+    test('returns BOTH_UNRESOLVED when both strings are tokens', () => {
+      expect(Token.compareStrings(Token.asString(123), Token.asString(456))).toBe(TokenComparison.BOTH_UNRESOLVED);
+    });
+  });
+});
+
+describe('Tokenization', () => {
+  describe('reverseString', () => {
+    test('returns fragments for string with tokens', () => {
+      const token = Token.asString(123);
+      const fragments = Tokenization.reverseString(`foo ${token} bar`);
+      expect(fragments.length).toBeGreaterThan(1);
+      expect(fragments.firstToken).toBeDefined();
+    });
+  });
+
+  describe('reverseCompleteString', () => {
+    test('returns token for encoded token string', () => {
+      const original = Token.asAny(123);
+      const encoded = Token.asString(original);
+      const reversed = Tokenization.reverseCompleteString(encoded);
+      expect(reversed).toBeDefined();
+    });
+
+    test('throws for concatenated string', () => {
+      const token = Token.asString(123);
+      expect(() => {
+        Tokenization.reverseCompleteString(`foo ${token}`);
+      }).toThrow(/must not be a concatenation/);
+    });
+  });
+
+  describe('reverse', () => {
+    test('returns original for IResolvable', () => {
+      const original: IResolvable = {
+        creationStack: [],
+        resolve: () => 'foo',
+      };
+      expect(Tokenization.reverse(original)).toBe(original);
+    });
+
+    test('returns undefined for non-token values', () => {
+      expect(Tokenization.reverse(123)).toBeUndefined();
+      expect(Tokenization.reverse('foo')).toBeUndefined();
+      expect(Tokenization.reverse({})).toBeUndefined();
+    });
+
+    test('handles failConcat option', () => {
+      const token = Token.asString(123);
+      expect(() => {
+        Tokenization.reverse(`foo ${token}`);
+      }).toThrow();
+      
+      expect(Tokenization.reverse(`foo ${token}`, { failConcat: false })).toBeUndefined();
+    });
+  });
+
+  describe('resolve', () => {
+    test('resolves token values', () => {
+      const stack = new Stack();
+      const token = Token.asAny('foo');
+      const resolved = Tokenization.resolve(token, {
+        scope: stack,
+        resolver: stack,
+      });
+      expect(resolved).toBe('foo');
+    });
+
+    test('handles preparing option', () => {
+      const stack = new Stack();
+      const token = Token.asAny('foo');
+      const resolved = Tokenization.resolve(token, {
+        scope: stack,
+        resolver: stack,
+        preparing: true,
+      });
+      expect(resolved).toBe('foo');
+    });
+
+    test('handles removeEmpty option', () => {
+      const stack = new Stack();
+      const obj = {
+        a: undefined,
+        b: 'foo',
+      };
+      
+      const resolvedWithRemove = Tokenization.resolve(obj, {
+        scope: stack,
+        resolver: stack,
+        removeEmpty: true,
+      });
+      expect(resolvedWithRemove).toEqual({ b: 'foo' });
+      
+      const resolvedWithoutRemove = Tokenization.resolve(obj, {
+        scope: stack,
+        resolver: stack,
+        removeEmpty: false,
+      });
+      expect(resolvedWithoutRemove).toEqual({ a: undefined, b: 'foo' });
+    });
+  });
+
+  describe('isResolvable', () => {
+    test('returns true for IResolvable objects', () => {
+      const resolvable: IResolvable = {
+        creationStack: [],
+        resolve: () => 'foo',
+      };
+      expect(Tokenization.isResolvable(resolvable)).toBe(true);
+    });
+
+    test('returns false for non-IResolvable objects', () => {
+      expect(Tokenization.isResolvable('foo')).toBe(false);
+      expect(Tokenization.isResolvable(123)).toBe(false);
+      expect(Tokenization.isResolvable({})).toBe(false);
+      expect(Tokenization.isResolvable(null)).toBe(false);
+      expect(Tokenization.isResolvable(undefined)).toBe(false);
+    });
+  });
+
+  describe('stringifyNumber', () => {
+    test('converts number to string', () => {
+      expect(Tokenization.stringifyNumber(123)).toBe('123');
+    });
+
+    test('returns token for token value', () => {
+      const token = Token.asAny(123);
+      const result = Tokenization.stringifyNumber(token as any);
+      expect(Tokenization.isResolvable(result)).toBe(true);
+    });
+
+    test('returns non-number values as-is', () => {
+      const obj = { foo: 'bar' };
+      expect(Tokenization.stringifyNumber(obj as any)).toBe(obj);
+    });
+  });
+});
+
+describe('JsonNull', () => {
+  test('INSTANCE is a singleton', () => {
+    expect(JsonNull.INSTANCE).toBe(JsonNull.INSTANCE);
+  });
+
+  test('resolve returns null', () => {
+    const context = {} as IResolveContext;
+    expect(JsonNull.INSTANCE.resolve(context)).toBe(null);
+  });
+
+  test('toJSON returns null', () => {
+    expect(JsonNull.INSTANCE.toJSON()).toBe(null);
+  });
+
+  test('toString returns "null"', () => {
+    expect(JsonNull.INSTANCE.toString()).toBe('null');
+  });
+});
+
+describe('withResolved', () => {
+  test('calls function with one resolved argument', () => {
+    const fn = jest.fn();
+    withResolved('foo', fn);
+    expect(fn).toHaveBeenCalledWith('foo');
+  });
+
+  test('calls function with two resolved arguments', () => {
+    const fn = jest.fn();
+    withResolved('foo', 'bar', fn);
+    expect(fn).toHaveBeenCalledWith('foo', 'bar');
+  });
+
+  test('calls function with three resolved arguments', () => {
+    const fn = jest.fn();
+    withResolved('foo', 'bar', 'baz', fn);
+    expect(fn).toHaveBeenCalledWith('foo', 'bar', 'baz');
+  });
+
+  test('does not call function when any argument is a token', () => {
+    const fn = jest.fn();
+    withResolved(Token.asString(123), fn);
+    expect(fn).not.toHaveBeenCalled();
+    
+    withResolved('foo', Token.asString(123), fn);
+    expect(fn).not.toHaveBeenCalled();
+    
+    withResolved('foo', 'bar', Token.asString(123), fn);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('does nothing with less than 2 arguments', () => {
+    expect(() => {
+      (withResolved as any)();
+    }).not.toThrow();
+    
+    expect(() => {
+      (withResolved as any)('foo');
+    }).not.toThrow();
+  });
+});

--- a/packages/aws-cdk-lib/core/test/token.test.ts.bak
+++ b/packages/aws-cdk-lib/core/test/token.test.ts.bak
@@ -1,0 +1,315 @@
+import { Stack } from '../lib';
+import { JsonNull, Token, TokenComparison, Tokenization, withResolved } from '../lib/token';
+import { IResolvable, IResolveContext } from '../lib/resolvable';
+
+describe('Token', () => {
+  describe('isUnresolved', () => {
+    test('returns true for tokens', () => {
+      expect(Token.isUnresolved(Token.asAny('foo'))).toBe(true);
+    });
+
+    test('returns false for non-tokens', () => {
+      expect(Token.isUnresolved('foo')).toBe(false);
+      expect(Token.isUnresolved(123)).toBe(false);
+      expect(Token.isUnresolved({})).toBe(false);
+      expect(Token.isUnresolved([])).toBe(false);
+    });
+  });
+
+  describe('asString', () => {
+    test('returns string for string value', () => {
+      expect(Token.asString('foo')).toBe('foo');
+    });
+
+    test('returns encoded token for non-string value', () => {
+      const token = Token.asString(123);
+      expect(typeof token).toBe('string');
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+
+    test('handles display hint', () => {
+      const token = Token.asString(123, { displayHint: 'test-hint' });
+      expect(typeof token).toBe('string');
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+  });
+
+  describe('asNumber', () => {
+    test('returns number for number value', () => {
+      expect(Token.asNumber(123)).toBe(123);
+    });
+
+    test('returns encoded token for non-number value', () => {
+      const token = Token.asNumber('foo');
+      expect(typeof token).toBe('number');
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+  });
+
+  describe('asList', () => {
+    test('returns string array for string array value', () => {
+      expect(Token.asList(['foo', 'bar'])).toEqual(['foo', 'bar']);
+    });
+
+    test('returns encoded token for non-string-array value', () => {
+      const token = Token.asList(123);
+      expect(Array.isArray(token)).toBe(true);
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+
+    test('handles display hint', () => {
+      const token = Token.asList(123, { displayHint: 'test-hint' });
+      expect(Array.isArray(token)).toBe(true);
+      expect(Token.isUnresolved(token)).toBe(true);
+    });
+  });
+
+  describe('asAny', () => {
+    test('returns IResolvable for any value', () => {
+      const token = Token.asAny('foo');
+      expect(Tokenization.isResolvable(token)).toBe(true);
+    });
+
+    test('returns original IResolvable for IResolvable value', () => {
+      const original: IResolvable = {
+        creationStack: [],
+        resolve: () => 'foo',
+      };
+      const token = Token.asAny(original);
+      expect(token).toBe(original);
+    });
+  });
+
+  describe('compareStrings', () => {
+    test('returns SAME for identical strings', () => {
+      expect(Token.compareStrings('foo', 'foo')).toBe(TokenComparison.SAME);
+    });
+
+    test('returns DIFFERENT for different strings', () => {
+      expect(Token.compareStrings('foo', 'bar')).toBe(TokenComparison.DIFFERENT);
+    });
+
+    test('returns ONE_UNRESOLVED when one string is a token', () => {
+      expect(Token.compareStrings('foo', Token.asString(123))).toBe(TokenComparison.ONE_UNRESOLVED);
+    });
+
+    test('returns BOTH_UNRESOLVED when both strings are tokens', () => {
+      expect(Token.compareStrings(Token.asString(123), Token.asString(456))).toBe(TokenComparison.BOTH_UNRESOLVED);
+    });
+  });
+});
+
+describe('Tokenization', () => {
+  describe('reverseString', () => {
+    test('returns fragments for string with tokens', () => {
+      const token = Token.asString(123);
+      const fragments = Tokenization.reverseString(`foo ${token} bar`);
+      expect(fragments.length).toBeGreaterThan(1);
+      expect(fragments.firstToken).toBeDefined();
+    });
+  });
+
+  describe('reverseNumber', () => {
+    test('returns undefined for non-token number', () => {
+      expect(Tokenization.reverseNumber(123)).toBeUndefined();
+    });
+
+    test('returns token for encoded number', () => {
+      const original = Token.asAny(123);
+      const encoded = Token.asNumber(original);
+      const reversed = Tokenization.reverseNumber(encoded);
+      expect(reversed).toBeDefined();
+    });
+  });
+
+  describe('reverseList', () => {
+    test('returns undefined for non-token list', () => {
+      expect(Tokenization.reverseList(['foo', 'bar'])).toBeUndefined();
+    });
+
+    test('returns token for encoded list', () => {
+      const original = Token.asAny(['foo', 'bar']);
+      const encoded = Token.asList(original);
+      const reversed = Tokenization.reverseList(encoded);
+      expect(reversed).toBeDefined();
+    });
+  });
+
+  describe('reverse', () => {
+    test('returns original for IResolvable', () => {
+      const original: IResolvable = {
+        creationStack: [],
+        resolve: () => 'foo',
+      };
+      expect(Tokenization.reverse(original)).toBe(original);
+    });
+
+    test('returns undefined for non-token values', () => {
+      expect(Tokenization.reverse(123)).toBeUndefined();
+      expect(Tokenization.reverse('foo')).toBeUndefined();
+      expect(Tokenization.reverse({})).toBeUndefined();
+    });
+
+    test('handles failConcat option', () => {
+      const token = Token.asString(123);
+      expect(() => {
+        Tokenization.reverse(`foo ${token}`);
+      }).toThrow();
+      
+      expect(Tokenization.reverse(`foo ${token}`, { failConcat: false })).toBeUndefined();
+    });
+    
+    test('reverses array values', () => {
+      const original = Token.asAny(['foo', 'bar']);
+      const encoded = Token.asList(original);
+      expect(Tokenization.reverse(encoded)).toBeDefined();
+    });
+    
+    test('reverses number values', () => {
+      const original = Token.asAny(123);
+      const encoded = Token.asNumber(original);
+      expect(Tokenization.reverse(encoded)).toBeDefined();
+    });
+  });
+
+  describe('resolve', () => {
+    test('resolves token values', () => {
+      const stack = new Stack();
+      const token = Token.asAny('foo');
+      const resolved = Tokenization.resolve(token, {
+        scope: stack,
+        resolver: stack,
+      });
+      expect(resolved).toBe('foo');
+    });
+
+    test('handles preparing option', () => {
+      const stack = new Stack();
+      const token = Token.asAny('foo');
+      const resolved = Tokenization.resolve(token, {
+        scope: stack,
+        resolver: stack,
+        preparing: true,
+      });
+      expect(resolved).toBe('foo');
+    });
+
+    test('handles removeEmpty option', () => {
+      const stack = new Stack();
+      const obj = {
+        a: undefined,
+        b: 'foo',
+      };
+      
+      const resolvedWithRemove = Tokenization.resolve(obj, {
+        scope: stack,
+        resolver: stack,
+        removeEmpty: true,
+      });
+      expect(resolvedWithRemove).toEqual({ b: 'foo' });
+      
+      const resolvedWithoutRemove = Tokenization.resolve(obj, {
+        scope: stack,
+        resolver: stack,
+        removeEmpty: false,
+      });
+      expect(resolvedWithoutRemove).toEqual({ a: undefined, b: 'foo' });
+    });
+  });
+
+  describe('isResolvable', () => {
+    test('returns true for IResolvable objects', () => {
+      const resolvable: IResolvable = {
+        creationStack: [],
+        resolve: () => 'foo',
+      };
+      expect(Tokenization.isResolvable(resolvable)).toBe(true);
+    });
+
+    test('returns false for non-IResolvable objects', () => {
+      expect(Tokenization.isResolvable('foo')).toBe(false);
+      expect(Tokenization.isResolvable(123)).toBe(false);
+      expect(Tokenization.isResolvable({})).toBe(false);
+      expect(Tokenization.isResolvable(null)).toBe(false);
+      expect(Tokenization.isResolvable(undefined)).toBe(false);
+    });
+  });
+
+  describe('stringifyNumber', () => {
+    test('converts number to string', () => {
+      expect(Tokenization.stringifyNumber(123)).toBe('123');
+    });
+
+    test('returns token for token value', () => {
+      const token = Token.asAny(123);
+      const result = Tokenization.stringifyNumber(token as any);
+      expect(Tokenization.isResolvable(result)).toBe(true);
+    });
+
+    test('returns non-number values as-is', () => {
+      const obj = { foo: 'bar' };
+      expect(Tokenization.stringifyNumber(obj as any)).toBe(obj);
+    });
+  });
+});
+
+describe('JsonNull', () => {
+  test('INSTANCE is a singleton', () => {
+    expect(JsonNull.INSTANCE).toBe(JsonNull.INSTANCE);
+  });
+
+  test('resolve returns null', () => {
+    const context = {} as IResolveContext;
+    expect(JsonNull.INSTANCE.resolve(context)).toBe(null);
+  });
+
+  test('toJSON returns null', () => {
+    expect(JsonNull.INSTANCE.toJSON()).toBe(null);
+  });
+
+  test('toString returns "null"', () => {
+    expect(JsonNull.INSTANCE.toString()).toBe('null');
+  });
+});
+
+describe('withResolved', () => {
+  test('calls function with one resolved argument', () => {
+    const fn = jest.fn();
+    withResolved('foo', fn);
+    expect(fn).toHaveBeenCalledWith('foo');
+  });
+
+  test('calls function with two resolved arguments', () => {
+    const fn = jest.fn();
+    withResolved('foo', 'bar', fn);
+    expect(fn).toHaveBeenCalledWith('foo', 'bar');
+  });
+
+  test('calls function with three resolved arguments', () => {
+    const fn = jest.fn();
+    withResolved('foo', 'bar', 'baz', fn);
+    expect(fn).toHaveBeenCalledWith('foo', 'bar', 'baz');
+  });
+
+  test('does not call function when any argument is a token', () => {
+    const fn = jest.fn();
+    withResolved(Token.asString(123), fn);
+    expect(fn).not.toHaveBeenCalled();
+    
+    withResolved('foo', Token.asString(123), fn);
+    expect(fn).not.toHaveBeenCalled();
+    
+    withResolved('foo', 'bar', Token.asString(123), fn);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('does nothing with less than 2 arguments', () => {
+    expect(() => {
+      (withResolved as any)();
+    }).not.toThrow();
+    
+    expect(() => {
+      (withResolved as any)('foo');
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
This PR adds additional tests to improve code coverage for the following files:

1. `token.ts`: Added comprehensive tests for `Token`, `Tokenization`, `JsonNull`, and `withResolved` classes and functions
2. `feature-flags.ts`: Added tests for expired flags and edge cases
3. `runtime-info.ts`: Added tests for `constructInfoFromConstruct`, `constructInfoFromStack`, and validation plugin handling

These changes should increase the code coverage to meet the required thresholds:
- `runtime-info.ts`: branches at 70.83% → should exceed 80%
- `feature-flags.ts`: branches at 75% → should exceed 80%
- `token.ts`: multiple metrics below threshold → should exceed 80%

The tests focus on previously untested code paths, particularly around error handling and edge cases.