### PR TITLE
Fix TypeScript errors in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,38 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
+import { Construct } from 'constructs';
 
-// Error 1: Wrong type assignment for interface property
+// Error 1: Fixed type assignment for interface property
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
+// Error 2: Fixed type declaration
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  readonly logGroup?: logs.ILogGroup;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+// Error 3: Fixed type mismatch in property
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  readonly s3?: S3LoggingOptions;
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
-  return group;
+// Error 4: Fixed return type and added required parameters
+export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id);
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
-  const s3Bucket: s3.IBucket = bucket;
-  return s3Bucket;
+// Error 5: Fixed parameter type
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
+  return bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+// Error 6: Fixed incompatible type assignment
+export function defaultLogGroup(scope: Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id);
+}


### PR DESCRIPTION
This PR fixes the TypeScript errors in the project-logs.ts file with minimal changes:

1. Removed interface property initializers which are not allowed in TypeScript
2. Added proper types to interface properties based on their usage in project.ts
3. Added required constructor arguments to LogGroup creation
4. Fixed parameter and return types in functions
5. Converted the constant defaultLogGroup to a function that returns a properly typed LogGroup

These changes resolve all the TypeScript compilation errors that were causing the build to fail.