### PR TITLE
Fix TypeScript errors in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,104 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
 
-// Error 1: Wrong type assignment for interface property
+/**
+ * Options for S3 logging for a CodeBuild Project
+ */
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  /**
+   * The S3 Bucket to send logs to
+   */
+  readonly bucket: s3.IBucket;
+  
+  /**
+   * The path prefix in the bucket for logs
+   * 
+   * @default - no prefix
+   */
+  readonly prefix?: string;
+  
+  /**
+   * Whether to enable S3 logging
+   * 
+   * @default true
+   */
+  readonly enabled?: boolean;
+  
+  /**
+   * Whether to disable encryption for the logs
+   * 
+   * @default false
+   */
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
+/**
+ * Options for CloudWatch logging for a CodeBuild Project
+ */
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  /**
+   * The CloudWatch log group to send logs to
+   */
+  readonly logGroup: logs.ILogGroup;
+  
+  /**
+   * The path prefix in the log group for logs
+   * 
+   * @default - no prefix
+   */
+  readonly prefix?: string;
+  
+  /**
+   * Whether to enable CloudWatch logging
+   * 
+   * @default true
+   */
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+/**
+ * Options for logging configuration for a CodeBuild Project
+ */
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  /**
+   * S3 logging options
+   * 
+   * @default - no S3 logging
+   */
+  readonly s3?: S3LoggingOptions;
+  
+  /**
+   * CloudWatch logging options
+   * 
+   * @default - no CloudWatch logging
+   */
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
-  return group;
+/**
+ * Creates a CloudWatch log group for CodeBuild
+ * 
+ * @returns The created log group
+ */
+export function createLogGroup(scope: logs.Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id);
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
-  const s3Bucket: s3.IBucket = bucket;
-  return s3Bucket;
+/**
+ * Configures S3 logging for a CodeBuild project
+ * 
+ * @param bucket The S3 bucket to use for logging
+ * @returns The S3 bucket configured for logging
+ */
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
+  return bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+/**
+ * Default log group for CodeBuild projects
+ */
+export const defaultLogGroup = (scope: logs.Construct, id: string): logs.LogGroup => {
+  return new logs.LogGroup(scope, id, {
+    logGroupName: 'my-log-group'
+  });
+};


### PR DESCRIPTION
This PR fixes TypeScript errors in the aws-codebuild/lib/project-logs.ts file.

The main changes include:

1. Removing initializers from interface properties which are not allowed in TypeScript
2. Properly defining the interface properties with correct types
3. Fixing function signatures to match their usage in project.ts
4. Adding proper JSDoc comments to improve code readability

These changes ensure that the interfaces and functions are properly typed and can be used correctly in the project.ts file.