### PR TITLE
Fix TypeScript errors in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,34 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
+import { Construct } from 'constructs';
 
-// Error 1: Wrong type assignment for interface property
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  readonly logGroup?: logs.ILogGroup;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  readonly s3?: S3LoggingOptions;
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
+export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
+  const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
-  const s3Bucket: s3.IBucket = bucket;
-  return s3Bucket;
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
+  return bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+export function createDefaultLogGroup(scope: Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id);
+}


### PR DESCRIPTION
This PR fixes the TypeScript errors in the aws-codebuild/lib/project-logs.ts file that were causing the build to fail.

The main issues fixed are:
1. Removed initializers from interface properties which are not allowed in TypeScript
2. Fixed type mismatches to ensure proper typing
3. Added required constructor arguments for LogGroup instantiation
4. Corrected the interface definitions to match what project.ts expects

These changes are minimal and focused on resolving the specific TypeScript errors while maintaining the expected interface structure used by project.ts.