### PR TITLE
fix: Correct TypeScript errors in project-logs.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
+++ b/packages/aws-cdk-lib/aws-codebuild/lib/project-logs.ts
@@ -1,32 +1,43 @@
 import * as logs from '../../aws-logs';
 import * as s3 from '../../aws-s3';
+import { Construct } from 'constructs';
 
-// Error 1: Wrong type assignment for interface property
+// Fixed interface definition without initializers
 export interface S3LoggingOptions {
-  readonly bucket: number = s3.Bucket;
+  readonly bucket: s3.IBucket;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
+  readonly encrypted?: boolean;
 }
 
-// Error 2: Invalid type declaration
+// Fixed interface definition without initializers
 export interface CloudWatchLoggingOptions {
-  readonly logGroup: boolean[] = logs.LogGroup;
+  readonly logGroup?: logs.ILogGroup;
+  readonly prefix?: string;
+  readonly enabled?: boolean;
 }
 
-// Error 3: Type mismatch in property
+// Fixed interface definition without initializers
 export interface LoggingOptions {
-  readonly s3: string = { bucket: new s3.Bucket() };
+  readonly s3?: S3LoggingOptions;
+  readonly cloudWatch?: CloudWatchLoggingOptions;
 }
 
-// Error 4: Wrong return type
-export function createLogGroup(): number[] {
-  const group: logs.LogGroup = new logs.LogGroup();
+// Fixed function with proper parameter types and return type
+export function createLogGroup(scope: Construct, id: string): logs.LogGroup {
+  const group = new logs.LogGroup(scope, id);
   return group;
 }
 
-// Error 5: Invalid parameter type
-export function configureS3Logging(bucket: boolean) {
+// Fixed function with proper parameter types
+export function configureS3Logging(bucket: s3.IBucket): s3.IBucket {
   const s3Bucket: s3.IBucket = bucket;
   return s3Bucket;
 }
 
-// Error 6: Incompatible type assignment
-export const defaultLogGroup: logs.LogGroup = "my-log-group";
+// Fixed constant with proper type
+export function getDefaultLogGroup(scope: Construct, id: string): logs.LogGroup {
+  return new logs.LogGroup(scope, id, { 
+    logGroupName: "my-log-group" 
+  });
+}


### PR DESCRIPTION
This PR fixes TypeScript errors in the `project-logs.ts` file that were causing the build to fail.

## Changes
- Removed initializers from interface properties (which are not allowed in TypeScript interfaces)
- Fixed type mismatches in functions and constants
- Added proper parameter types for constructor calls
- Added optional properties to interfaces to match usage in project.ts

## Root Cause
The build was failing due to TypeScript compilation errors in the `aws-codebuild/lib/project-logs.ts` file. The file contained interface properties with initializers, type mismatches, and constructor parameter errors.

## Testing
This change should allow the build to complete successfully.